### PR TITLE
update seed configs

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -28,5 +28,8 @@ models:
 
 seeds:
   jaffle_shop:
-    +column_types:
-      order_date: TEXT
+    +pre-hook: "set firebolt_dont_wait_for_upload_to_s3=1" # WARNING: alpha feature
+    +quote_columns: true
+    raw_orders:
+      +column_types:
+        order_date: TEXT


### PR DESCRIPTION
earlier i introduced a bug by specify a column option for `order_date` which was applied to all seed tables. this corrects it. We're also adding:
- a `pre-hook` to make table performance faster, and
- a `quote_columns` param to remove a deprecation warning