### PR TITLE
chore(FIR-24766): Remove not needed override for column type

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -34,6 +34,3 @@ seeds:
   +quote_columns: true
   jaffle_shop:
     +quote_columns: true
-    raw_orders:
-      +column_types:
-        order_date: TEXT


### PR DESCRIPTION
This was an issue with an old implementation, using JDBC. We no longer need this override since the column is resolved to DATE correctly.